### PR TITLE
travis-ci でPHP5.3と実行できるよう修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
 
-sudo: false
+sudo: required
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -31,6 +30,9 @@ env:
 
 matrix:
   fast_finish: true
+  include: 
+    - php: 5.3
+      dist: precise
 
 before_script:
   # archive plugin

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,6 @@ env:
     - ECCUBE_VERSION=master DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=master DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
 
-    # ec-cube 3.0.9
-    - ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    # ec-cube 3.0.10
-    - ECCUBE_VERSION=3.0.10 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0.10 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-
 matrix:
   fast_finish: true
   include: 


### PR DESCRIPTION
##概要(Overview・Refs Issue)
travisの問題に関しては、下記のようなことを修正します。
・「3.0.9」と「3.0.10」バージョンを削除する
・PHP5.3に対応します。下記のソースを追加します。
    include:
     - php: 5.3
       dist: precise
・travisの環境：「sudo: false」を「sudo: required」に変更します。
※理由は
・Trustyステータスで、TravisがPHP5.3にサポートしないからです。（https://blog.travis-ci.com/2017-08-31-trusty-as-default-status）
・「sudo: false」を「sudo: required」に変更することに関しては、https://github.com/travis-ci/travis-ci/issues/6861参照お願いいたします